### PR TITLE
blah 2.6.0 Improved documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,24 +1,21 @@
-The KINDLY License
+The MIT License (MIT)
+
 Copyright (c) 2014-15 Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)
 
-You have the permission to use this software, read its source code, modify and
-redistribute it under the following terms:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
- - if you want to use this software or include parts of its code in a
-   closed-source or commercial project you should kindly ask the
-   author (via a private message or email) and get a positive answer
- - this license should be included in the modified versions of this software
- - in case of redistributing modified copies, you are encouraged to clearly
-   indicate that the copies are based on this work
- - if you think that your redistributed copy is awesome, you are encouraged to
-   show the author of this software what you did and how you helped the others
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-You are free to install and use this software on as many machines as you want,
-free of charge, making sure you met the terms above.
-
-You are encouraged to kindly support the software and its author by:
-
- - sharing his/her work
- - reporting issues/bugs and asking for feature requests
- - donating money or any other things that can help the author
- - contribute on the software code by fixing bugs and adding features
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Documentation can be found at https://github.com/IonicaBizau/blah
 Here is an example how to use this package as library. To install it locally, as library, you can do that using `npm`:
 
 ```sh
-$ npm i blah
+$ npm i --save blah
 ```
 
 ```js
@@ -83,13 +83,12 @@ If you are using this library in one of your projects, add it in this list. :spa
 
 ## License
 
-[KINDLY][license] © [Ionică Bizău][website]
+[MIT][license] © [Ionică Bizău][website]
 
-[license]: http://ionicabizau.github.io/kindly-license/?author=Ionic%C4%83%20Biz%C4%83u%20%3Cbizauionica@gmail.com%3E&year=2014
-
-[website]: http://ionicabizau.net
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 
+[license]: http://showalicense.com/?fullname=Ionic%C4%83%20Biz%C4%83u%20%3Cbizauionica%40gmail.com%3E%20(http%3A%2F%2Fionicabizau.net)&year=2014#license-mit
+[website]: http://ionicabizau.net
 [contributing]: /CONTRIBUTING.md
 [docs]: /DOCUMENTATION.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blah",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A command line tool to optimize the repetitive actions.",
   "main": "lib/index.js",
   "scripts": {
@@ -27,7 +27,7 @@
     "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
     "Silviu Bogan <silviubogan@gmail.com> (https://github.com/silviubogan)"
   ],
-  "license": "KINDLY",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/blah/issues"
   },


### PR DESCRIPTION
 - Added package.json
 - Improved the documentation.
 - Integrated **[json2md](https://github.com/IonicaBizau/json2md)** with **[blah](https://github.com/IonicaBizau/blah)** to get the best flexibility in generating documentation. :dizzy:
 - Relicense to [MIT and link to the license](http://showalicense.com). :heart:

Regarding the integration of **json2md** into **blah**, [read this blog post I wrote](http://ionicabizau.net/blog/27-how-to-convert-json-to-markdown-using-json2md).
