### PR TITLE
2.7.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,7 @@ Blah.prototype.readme = function (callback) {
     OneByOne([
         self.prepare.bind(self)
       , function (next) {
-            self.docs(self.pack.main, false, next);
+            self.docs(self.pack.blah.main || self.pack.main, false, next);
         }
       , function (next, docs) {
             self.render(self.paths.readme, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blah",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "A command line tool to optimize the repetitive actions.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
When generating the docs, if there is a `blah.main` field pointining to a file, it will have priority.
This is handy when generating module bundles/dist files etc. :rocket: